### PR TITLE
Reset published ports in the production compose file

### DIFF
--- a/docker-compose.prod.override.yml
+++ b/docker-compose.prod.override.yml
@@ -7,6 +7,7 @@ services:
     image: ghcr.io/gisdevio/tools4msp-geoplatform:${GEOPLATFORM_IMAGE_VERSION}
 
   geonode:
+    ports: !reset []
     labels:
       traefik.enable: true
       traefik.http.routers.tools4msp_geoplatform_geonode_router.rule: Host(`dev.geoplatform.tools4msp.eu`)


### PR DESCRIPTION
This PR adds a missing reset of the ports published by the `geonode` service to an empty array.


Since the production environment is already using a traefik instance to manage traffic for ports 80 and 443, the production compose override cannot be trying to publish to those same ports.