### PR TITLE
compose production override now uses custom network

### DIFF
--- a/docker-compose.prod.override.yml
+++ b/docker-compose.prod.override.yml
@@ -1,10 +1,21 @@
+# NOTE: all services use the `web` network in order to overcome mtu
+# limitations. The `web` network has mtu:1400
+#
+
+x-common-networks: &common-networks
+  networks:
+    - web
+
+
 services:
   django:
     image: ghcr.io/gisdevio/tools4msp-geoplatform:${GEOPLATFORM_IMAGE_VERSION}
     build: !reset null
+    <<: *common-networks
 
   celery:
     image: ghcr.io/gisdevio/tools4msp-geoplatform:${GEOPLATFORM_IMAGE_VERSION}
+    <<: *common-networks
 
   geonode:
     ports: !reset []
@@ -13,11 +24,23 @@ services:
       traefik.http.routers.tools4msp_geoplatform_geonode_router.rule: Host(`dev.geoplatform.tools4msp.eu`)
       traefik.http.routers.tools4msp_geoplatform_geonode_router.tls.certresolver: le
       traefik.http.routers.tools4msp_geoplatform_geonode_router.entrypoints: websecure
-    networks:
-      - web
+    <<: *common-networks
+
+  memcached:
+    <<: *common-networks
 
   geoserver:
     ports: !reset []
+    <<: *common-networks
+
+  data-dir-conf:
+    <<: *common-networks
+
+  db:
+    <<: *common-networks
+
+  rabbitmq:
+    <<: *common-networks
 
 
 networks:


### PR DESCRIPTION
In the production environment the default MTU[^1] of 1500 does not work, thus the docker compose override needs to ensure all services use the external docker network, which had previously been created with an MTU of 1400 - this was originally done in order to mimic the settings of the legacy system but I had not realized that this setting was an absolute requirement in order for the stack to be able to work. 

Without this modification the docker services are not able to communicate with the external web. The proposed changes ensure everything works OK though.


[^1]: https://www.cloudflare.com/learning/network-layer/what-is-mtu/