### PR TITLE
Removed wagtail-related packages and configuration

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,9 +1,6 @@
 -e git+https://github.com/GeoNode/geonode-mapstore-client.git@4.4.x#egg=django_geonode_mapstore_client
 -e git+https://github.com/GeoNode/geonode-importer.git@1.1.x#egg=geonode-importer
 -e git+https://github.com/GeoNode/geonode.git@4.4.x#egg=GeoNode
-# -e git+https://github.com/ilpise/geonode.git@wagtail#egg=GeoNode
-# -e git+https://github.com/ilpise/geonode.git@wagtail
--e git+https://github.com/ilpise/wagtail.git@geonode#egg=wagtail
 
 django-media-fixtures==1.0.0 # <-
 django-webpack-loader # <-

--- a/src/tools4msp_geoplatform/settings.py
+++ b/src/tools4msp_geoplatform/settings.py
@@ -76,7 +76,6 @@ STATICFILES_DIRS = [
     os.path.join(LOCAL_ROOT, "static"),
     os.path.join(PROJECT_ROOT, "frontend", "static"), # for geodatabuilders and casestudies
     # os.path.join(PROJECT_ROOT, "static"),
-    # '/home/ilpise/gisdevio/.gpvenv/src/wagtail/wagtail/admin/static'
 ] + list(STATICFILES_DIRS)
 
 # Location of locale files
@@ -178,21 +177,8 @@ if LDAP_ENABLED and "geonode_ldap" not in INSTALLED_APPS:
 # https://docs.geonode.org/en/master/advanced/contrib/#configuration
 
 
-# Wagtail integration
-
 INSTALLED_APPS +=(
                 'django_media_fixtures',
-                # 'wagtail.contrib.forms',
-                # 'wagtail.contrib.redirects',
-                # 'wagtail.embeds',
-                # 'wagtail.sites',
-                # 'wagtail.users',
-                # 'wagtail.snippets',
-                # 'wagtail.documents',
-                # 'wagtail.images',
-                # 'wagtail.search',
-                # 'wagtail.admin',
-                # 'wagtail',
                 # 'modelcluster',
                 # 'taggit' # error django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: taggit
                 )
@@ -396,26 +382,3 @@ if GMAPS_TOKEN:
             "group": "background",
             "visibility": True
         })
-
-# # wagtail
-# MIDDLEWARE += (#'allauth.account.middleware.AccountMiddleware', # django.core.exceptions.ImproperlyConfigured: allauth.account.middleware.AccountMiddleware must be added to settings.MIDDLEWARE
-#               #'django.contrib.sessions.middleware.SessionMiddleware',
-#               #'django.contrib.auth.middleware.AuthenticationMiddleware',
-#               #'django.contrib.messages.middleware.MessageMiddleware',
-#               'wagtail.contrib.redirects.middleware.RedirectMiddleware',)
-#
-# # Add a STATIC_ROOT setting, if your project doesn’t have one already
-# # STATIC_ROOT is the destination of static files
-# #
-# # You have requested to collect static files at the destination
-# # location as specified in your settings:
-# # STATIC_ROOT is '/home/ilpise/gisdevio/.gpvenv/src/geonode/geonode/static_root'
-#
-# MEDIA_ROOT = os.path.join(LOCAL_ROOT, 'media')
-# MEDIA_URL = '/media/'
-#
-# WAGTAIL_SITE_NAME = 'My Example Site'
-#
-# WAGTAILADMIN_BASE_URL = 'http://example.com'
-#
-# WAGTAILDOCS_EXTENSIONS = ['csv', 'docx', 'key', 'odt', 'pdf', 'pptx', 'rtf', 'txt', 'xlsx', 'zip']

--- a/src/tools4msp_geoplatform/urls.py
+++ b/src/tools4msp_geoplatform/urls.py
@@ -30,10 +30,6 @@ from geonode.base import register_url_event
 
 from .views import HomePageView
 
-# from wagtail.admin import urls as wagtailadmin_urls
-# from wagtail import urls as wagtail_urls
-# from wagtail.documents import urls as wagtaildocs_urls
-
 """
 # You can register your own urlpatterns here
 urlpatterns = [
@@ -52,16 +48,6 @@ urlpatterns = [
 ] + geonode_urlpatterns
 
 homepage = register_url_event()(HomePageView.as_view())
-
-# urlpatterns = [
-#     path('', homepage, name='home'),
-# ] + urlpatterns
-#
-# urlpatterns = [
-#     path('cms/', include(wagtailadmin_urls)),
-#     path('documents/', include(wagtaildocs_urls)),
-#     path('pages/', include(wagtail_urls)),
-# ] + urlpatterns
 
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
The reason being that wagtail is not compatible with the current GeoNode v4.4.x upstream branch

This PR makes it possible to build the project's docker image again.


---

- fixes #31