### PR TITLE
Create remote profile whenever it is needed rather than on user creation

### DIFF
--- a/src/casestudies/models.py
+++ b/src/casestudies/models.py
@@ -1,12 +1,7 @@
 import logging
-import traceback
 
 from django.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.contrib.auth import get_user_model
-
-from casestudies.libs import create_remote_user
 
 
 User = get_user_model()
@@ -55,19 +50,3 @@ class RemoteProfile(models.Model):
 
     def __str__(self):
         return str(self.remote_id)
-
-
-@receiver(post_save, sender=User)
-def populate_profile(sender, instance, **kwargs):
-    if not hasattr(instance, 'remote_profile'):
-        # invoke API to create a user on tools4msp
-        try:
-            result, status = create_remote_user(instance)
-            if result.get('user'):
-                RemoteProfile.objects.create(user=instance, remote_id=result.get('user'), token=result.get('token'))
-                logger.debug(f'added profile to user {instance} ')
-            else:
-                logger.error(f'response from remote profile not found for user {instance}')
-                logger.debug(f'{result}')
-        except:
-            logger.error(traceback.format_exc())

--- a/src/core/libs.py
+++ b/src/core/libs.py
@@ -1,10 +1,12 @@
-import requests
 import logging
-import urllib
-import coreapi
-import string, random
+import urllib.parse
 from json.decoder import JSONDecodeError
+
+import requests
 from django.conf import settings
+from django.contrib.auth.models import User
+
+from casestudies import models
 
 
 logger = logging.getLogger('casestudies')
@@ -20,40 +22,138 @@ class APIValidationError(APIError):
     pass
 
 
-def call_api(params=None, method='GET', url=None, full_url=None, json=None, user=None):
-    headers = None
+def create_remote_user(
+        local_user_name: str,
+        remote_user_prefix: str,
+        remote_api_base_url: str,
+        remote_api_token: str
+) -> tuple[str, str]:
+    """Creates a user on the remote Tools4MSP instance."""
+
+    response = requests.post(
+        f'{remote_api_base_url}/api/v2/auth/createuser/',
+        headers={
+            'Authorization': f'Token {remote_api_token}'
+        },
+        json={
+            'username': f'{remote_user_prefix}__{local_user_name}'
+        }
+    )
+    logger.debug(
+        f'Tried to create remote user at {response.request.url=} '
+        f'with {response.request.headers=} and {response.request.body=}'
+    )
+    logger.debug(f'{response.status_code=} {response.text=}')
+    if response.status_code not in (200, 201):
+        # remote API is currently returning HTTP 200 - OK instead of the
+        # usual HTTP 201 - Created on creation, so let's accept both
+        raise APIError(
+            'Could not create remote user',
+            status=response.status_code,
+            data=response.text
+        )
+    try:
+        payload = response.json()
+        remote_user_name = payload['user']
+        token = payload['token']
+    except JSONDecodeError:
+        raise APIError(
+            'Could not decode remote response',
+            status=400,
+            data=response.text
+        )
+    except KeyError:
+        raise APIError(
+            'Could not extract new user details from the remote response',
+            status=400,
+            data=response.text
+        )
+    return remote_user_name, token
+
+
+def create_local_user_remote_profile(
+        user: User,
+        remote_api_base_url: str,
+        remote_user_prefix: str,
+        remote_api_token: str,
+) -> models.RemoteProfile:
+    """Creates a local RemoteProfile for the given user.
+
+    This function assumes that the user does not have a RemoteProfile yet.
+    It creates a remote user on the Tools4MSP instance and then creates
+    a local RemoteProfile linked to the given user.
+    """
+    remote_user_name, token = create_remote_user(
+        user.username,
+        remote_api_base_url=remote_api_base_url,
+        remote_user_prefix=remote_user_prefix,
+        remote_api_token=remote_api_token,
+    )
+    profile = models.RemoteProfile.objects.create(
+        user=user,
+        remote_id=remote_user_name,
+        token=token
+    )
+    return profile
+
+
+def call_api(
+        params=None,
+        method='GET',
+        url=None,
+        full_url=None,
+        json=None,
+        user: User | None = None
+):
+    headers = {}
     qparams = ''
 
     if params:
         qparams = '?' + urllib.parse.urlencode(params, doseq=False)
 
-    if user and user.is_authenticated and hasattr(user, 'remote_profile'):
-        token = user.remote_profile.token
-        headers = {'Authorization': f'Token {token}'}
+    if user:
+        if not hasattr(user, 'remote_profile'):
+            create_local_user_remote_profile(
+                user,
+                remote_api_base_url=settings.TOOLS4MSP_API_URL,
+                remote_user_prefix=settings.TOOLS4MSP_USER_PREFIX,
+                remote_api_token=settings.TOOLS4MSP_ADMIN_TOKEN,
+            )
+        headers.update(
+            {
+                'Authorization': f'Token {user.remote_profile.token}'
+            }
+        )
 
     internal_url = full_url if full_url else f"{settings.TOOLS4MSP_API_URL}/{url}{qparams}"
 
     logger.debug(internal_url)
-    r = requests.request(method=method, url=internal_url, headers=headers, json=json)
-    logger.debug(f'API returned {r.status_code} {r.text}')
+    response = requests.request(
+        method=method,
+        url=internal_url,
+        headers=headers or None,
+        json=json
+    )
+    logger.debug(f'API returned {response.status_code} {response.text}')
 
-    if r.status_code >= 500:
-        logger.error(f'API returned {r.status_code} {r.text}')
-        raise APIError('Internal Server Error', r.status_code)
-    elif r.status_code >= 400:
+    if response.status_code >= 500:
+        # when upstream returns with 50x we raise a 502 - Bad Gateway to denote
+        # the server error is on the upstream, not here
+        raise APIError(response.text, 502)
+    elif response.status_code >= 400:
         try:
-            content = r.json()
+            content = response.json()
 
-            if r.status_code == 403:
+            if response.status_code == 403:
                 raise PermissionError(content.get('detail'))
 
-            if r.status_code == 400 and type(content) is list:
-                raise APIValidationError('Tools4MSP Error', r.status_code, content)
+            if response.status_code == 400 and type(content) is list:
+                raise APIValidationError('Tools4MSP Error', response.status_code, content)
 
-            raise APIError(content.get('detail'), r.status_code, content)
+            raise APIError(content.get('detail'), response.status_code, content)
         except JSONDecodeError:
-            raise APIError('Invalid JSON returned', r.status_code)
+            raise APIError('Invalid JSON returned', response.status_code)
     try:
-        return r.json()
+        return response.json()
     except JSONDecodeError:
-        raise APIError('Invalid JSON returned', r.status_code)
+        raise APIError('Invalid JSON returned', response.status_code)


### PR DESCRIPTION
This PR modifies the way remote users on the TOOLS4MSP API are created by the geoportal.

The previous behavior tried to create a remote user when a new local user was created. It listened to the django model post_save signal.

The proposed PR instead will always try to create a remote profile if the user does not have one when needed. This way, pre-existing users will get a chance to register on the remote TOOLS4MSP API if by some reason the creation of their remote profile did not work on the first attempt.

Implementation details:

- The main changes are in the `core.libs` module, where the `call_api()` function will now always try to create a remote user when it is being called with a django user instance as an argument and this django user instance does not have a related user profile yet.
- The changes in `casestudies.models` are just the removal of the previous mechanism, which used django signals to create the user's remote profile - this is not needed anymore, as the proposed implementation will create the remote profile when needed, not during user creation
- The changes in `casestudies.api.views` are mostly to guard all calls to `core.libs.call_api()` with a `try.. except APIError` block. This is needed because `call_api()` can now fail if it is not able to create a new user, and this must be handled

---

- fixes #25