### PR TITLE
Send uwsgi logs to stdout

### DIFF
--- a/src/uwsgi.ini
+++ b/src/uwsgi.ini
@@ -1,7 +1,6 @@
 [uwsgi]
 # uwsgi-socket = 0.0.0.0:8000
 http-socket = 0.0.0.0:8000
-logto = /var/log/geonode.log
 # pidfile = /tmp/geonode.pid
 
 chdir = /usr/src/tools4msp_geoplatform/


### PR DESCRIPTION
This PR modifies the django container's uwsgi configuration in order to make its logs be output to stdout instead of a file. This allows logs to be handled by docker, thus enabling checking all container-related logs with the usual `docker logs` command.

- Related to #35