### PR TITLE
Added json extension to list of supported uploader files

### DIFF
--- a/src/tools4msp_geoplatform/settings.py
+++ b/src/tools4msp_geoplatform/settings.py
@@ -198,7 +198,8 @@ UPLOADER['SUPPORTED_CRS'] += [
 ]
 
 UPLOADER['SUPPORTED_EXT'] += [
-    '.geotiff'
+    '.geotiff',
+    '.json',
 ]
 
 # Add JSON support for documents


### PR DESCRIPTION
This PR adds `.json` to the list of extensions supported by the GeoNode uploader, thus making it possible to upload JSON files to the platform.

---

- Fixes #34